### PR TITLE
子付款方式、url 變數命名參照

### DIFF
--- a/lib/active_merchant/billing/integrations/allpay.rb
+++ b/lib/active_merchant/billing/integrations/allpay.rb
@@ -13,6 +13,20 @@ module ActiveMerchant #:nodoc:
         PAYMENT_CVS         = 'CVS'
         PAYMENT_ALIPAY      = 'Alipay'
 
+        SUBPAYMENT_ATM_TAISHIN      = 'TAISHIN'
+        SUBPAYMENT_ATM_ESUN         = 'ESUN'
+        SUBPAYMENT_ATM_HUANAN       = 'HUANAN'
+        SUBPAYMENT_ATM_BOT          = 'BOT'
+        SUBPAYMENT_ATM_FUBON        = 'FUBON'
+        SUBPAYMENT_ATM_CHINATRUST   = 'CHINATRUST'
+        SUBPAYMENT_ATM_FIRST        = 'FIRST'
+
+        SUBPAYMENT_CVS_CVS    = 'CVS'
+        SUBPAYMENT_CVS_OK     = 'OK'
+        SUBPAYMENT_CVS_FAMILY = 'FAMILY'
+        SUBPAYMENT_CVS_HILIFE = 'HILIFE'
+        SUBPAYMENT_CVS_IBON   = 'IBON'
+
         PAYMENT_TYPE        = 'aio'
 
         mattr_accessor :service_url

--- a/lib/active_merchant/billing/integrations/allpay/helper.rb
+++ b/lib/active_merchant/billing/integrations/allpay/helper.rb
@@ -21,16 +21,18 @@ module ActiveMerchant #:nodoc:
           mapping :total_amount, 'TotalAmount'
           mapping :amount, 'TotalAmount' # AM common
           # 付款完成通知回傳網址
-          mapping :return_url, 'ReturnURL' # AM common
+          mapping :notify_url, 'ReturnURL' # AM common
           # Client 端返回廠商網址
-          mapping :client_back_url, 'ClientBackURL'
-          # mapping :return_url, 'ClientBackURL' # AM common
+          # mapping :client_back_url, 'ClientBackURL'
+          mapping :return_url, 'ClientBackURL' # AM common
           # 付款完成 redirect 的網址
           mapping :redirect_url, 'OrderResultURL'
           # 交易描述
           mapping :description, 'TradeDesc'
-          # ATM, CVS 序號回傳網址
+          # ATM, CVS 序號回傳網址 (Server Side)
           mapping :payment_info_url, 'PaymentInfoURL'
+          # ATM, CVS 序號頁面回傳網址 (Client Side)
+          mapping :payment_redirect_url, 'ClientRedirectURL'
 
           ### Allpay 專屬介面
 

--- a/lib/active_merchant/billing/integrations/allpay/helper.rb
+++ b/lib/active_merchant/billing/integrations/allpay/helper.rb
@@ -51,6 +51,8 @@ module ActiveMerchant #:nodoc:
           #   ALL:不指定付款方式, 由歐付寶顯示付款方式 選擇頁面
           mapping :choose_payment, 'ChoosePayment'
 
+          mapping :choose_sub_payment, 'ChooseSubPayment'
+
           # 商品名稱
           # 多筆請以井號分隔 (#)
           mapping :item_name, 'ItemName'


### PR DESCRIPTION
* support for subpayment (ATM, CVS)

* return_url 設為使用者付款後瀏覽器導回的 url
* notify_url 設為伺服器端通知的 url
這樣才能跟其他實作保持通用。
關於其他實作的例子請見下表：
https://docs.google.com/spreadsheets/d/13i41t3ZZ_LoW59ayt1C9oy-3XGWhArVugWuCKDDpnKo/edit?usp=sharing

